### PR TITLE
fix: pin @raydium-io/raydium-sdk to exact 1.3.1-beta.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@coral-xyz/anchor": "^0.29.0",
-    "@raydium-io/raydium-sdk": "^1.3.1-beta.50",
+    "@raydium-io/raydium-sdk": "1.3.1-beta.50",
     "@solana/spl-token": "^0.4.1",
     "bs58": "^5.0.0",
     "dotenv": "^16.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,7 +74,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
-"@raydium-io/raydium-sdk@^1.3.1-beta.50":
+"@raydium-io/raydium-sdk@1.3.1-beta.50":
   version "1.3.1-beta.50"
   resolved "https://registry.yarnpkg.com/@raydium-io/raydium-sdk/-/raydium-sdk-1.3.1-beta.50.tgz#586b12f79b6a1217ee23ec20254767011146a21d"
   integrity sha512-leYSECA5s1kaJKV3ryLOPaJ0jt8665q08PZ0MmsQYtVUOjwnB9yEBxpOv/KyO+Kx8eOeZ1NQVXGMiKO0/lhCXw==


### PR DESCRIPTION
## Context

Refs #15.

The example depends on the **legacy v1** SDK (`@raydium-io/raydium-sdk`), published only as `1.3.1-beta.*` pre-releases whose TypeScript types have drifted over the API's life — e.g. the `Token` constructor gaining a `programId` argument, and `makeTxVersion` being added to the swap-instruction params. Those are the changes behind the compile errors reported in #15 (`makeTxVersion` not existing on the params type; `PublicKey` vs `number` argument mismatches): they trace to the **pre-`beta.50` SDK API**, not to this repo's source (which has been unchanged on those lines since the initial commit).

## What this PR is — and isn't

I reproduced first, and want to be straight about the result: **the example currently builds clean.** `tsc --noEmit` passes against *every* version the `^1.3.1-beta.50` caret can resolve to — `beta.50` through `beta.58` (the complete eligible set: the caret floors out the broken pre-`.50` betas, and `1.3.0` / `2.0.0-beta.0` are out of range). So **this is not a fix for a reproducible failure today.**

It's a **preventive pin**. A caret over an unstable pre-release line is fragile:
- it can drift to a future beta whose types differ (re-introducing #15), and
- it resolves ambiguously across package managers / their versions.

## Fix

Pin to an exact, known-good version and align the `yarn.lock` key so every install is deterministic:

```diff
- "@raydium-io/raydium-sdk": "^1.3.1-beta.50"
+ "@raydium-io/raydium-sdk": "1.3.1-beta.50"
```

Resolved version is unchanged (`beta.50`) — **no behavior change, no source edit.** Two-line diff (`package.json` + `yarn.lock`).

## Verification

```
$ npx tsc --noEmit
$ echo $?
0

$ npm ls @raydium-io/raydium-sdk
raydium-swap-example@1.0.0
`-- @raydium-io/raydium-sdk@1.3.1-beta.50
```

`npm run swap` (simulation mode, `executeSwap: false`) also runs end-to-end without a type or runtime crash.

## Follow-ups (intentionally out of scope)

Kept this PR minimal. Natural next steps, happy to open separately:
- a `typecheck` script + CI to catch future dependency drift automatically;
- migrating to the current [`@raydium-io/raydium-sdk-v2`](https://github.com/raydium-io/raydium-sdk-V2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)